### PR TITLE
WIP: dialog: added new parameter rr_noskip

### DIFF
--- a/src/modules/dialog/dialog.c
+++ b/src/modules/dialog/dialog.c
@@ -131,6 +131,7 @@ int early_dlgs_cnt = 0;
 int detect_spirals = 1;
 int dlg_send_bye = 0;
 int dlg_timeout_noreset = 0;
+int dlg_rr_noskip = 0;
 stat_var *active_dlgs = 0;
 stat_var *processed_dlgs = 0;
 stat_var *expired_dlgs = 0;
@@ -301,6 +302,7 @@ static param_export_t mod_params[]={
 	{ "ka_timer",              INT_PARAM, &dlg_ka_timer             },
 	{ "ka_interval",           INT_PARAM, &dlg_ka_interval          },
 	{ "timeout_noreset",       INT_PARAM, &dlg_timeout_noreset      },
+	{ "rr_noskip",             INT_PARAM, &dlg_rr_noskip            },
 	{ "timer_procs",           PARAM_INT, &dlg_timer_procs          },
 	{ "track_cseq_updates",    PARAM_INT, &_dlg_track_cseq_updates  },
 	{ "lreq_callee_headers",   PARAM_STR, &dlg_lreq_callee_headers  },
@@ -555,6 +557,12 @@ static int mod_init(void)
 	if (dlg_timeout_noreset != 0 && dlg_timeout_noreset != 1) {
 		LM_ERR("invalid value %d for timeout_noreset param!!\n",
 				dlg_timeout_noreset);
+		return -1;
+	}
+
+	if (dlg_rr_noskip != 0 && dlg_rr_noskip != 1) {
+		LM_ERR("invalid value %d for rr_noskip param!!\n",
+				dlg_rr_noskip);
 		return -1;
 	}
 

--- a/src/modules/dialog/dlg_handlers.c
+++ b/src/modules/dialog/dlg_handlers.c
@@ -65,6 +65,7 @@ static int       seq_match_mode;	/*!< dlg_match mode */
 static int       shutdown_done = 0;	/*!< 1 when destroy_dlg_handlers was called */
 extern int       detect_spirals;
 extern int       dlg_timeout_noreset;
+extern int       dlg_rr_noskip;
 extern int       initial_cbs_inscript;
 extern int       dlg_send_bye;
 extern int       dlg_event_rt[DLG_EVENTRT_MAX];
@@ -227,11 +228,15 @@ int populate_leg_info( struct dlg_cell *dlg, struct sip_msg *msg,
 		skip_recs = 0;
 	} else {
 		/* was the 200 OK received or local generated */
-		skip_recs = dlg->from_rr_nb +
-			((t->relayed_reply_branch>=0)?
-				((t->uac[t->relayed_reply_branch].flags&TM_UAC_FLAG_R2)?2:
-				 ((t->uac[t->relayed_reply_branch].flags&TM_UAC_FLAG_RR)?1:0))
-				:0);
+		if (dlg_rr_noskip) {
+			skip_recs = dlg->from_rr_nb;
+		} else {
+			skip_recs = dlg->from_rr_nb +
+				((t->relayed_reply_branch>=0)?
+					((t->uac[t->relayed_reply_branch].flags&TM_UAC_FLAG_R2)?2:
+					 ((t->uac[t->relayed_reply_branch].flags&TM_UAC_FLAG_RR)?1:0))
+					:0);
+		}
 	}
 
 	if(msg->record_route){


### PR DESCRIPTION
When doing dialog-based topology stripping, module built requests (like end of dialog BYEs) must ahve the correct route set. The new parameter allows the dialog module to build the route-set for legA and legB taking in count the topology strip.
This branch is not to merge. The branch for merging the feature in 5.1-sphere is this one: https://github.com/TheSphereIO/kamailio-src/tree/dialog_rr_5.1